### PR TITLE
fast clean up of the build setup - something quick and dirty that works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ CMD ["/sbin/entrypoint.sh"]
 ARG cachet_ver
 ARG archive_url
 
-ENV cachet_ver ${cachet_ver:-2.4.6}
+ENV cachet_ver ${cachet_ver}
 ENV archive_url ${archive_url:-https://github.com/klarrio/Cachet/archive/${cachet_ver}.tar.gz}
 
 ENV COMPOSER_VERSION 1.9.0

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 SILENT :
 .PHONY : test
 
+
+REPOSITORY := $(shell cat REPO)
+VERSION := $(shell cat VERSION)
+BUILD_TIME := $(shell date +%FT%T%z)
+GITREV := $(shell git rev-parse HEAD)
+
 update-dependencies:
 	docker pull curlimages/curl:latest
 	docker pull postgres:9.5
@@ -15,4 +21,7 @@ compose-up:
 	docker-compose up
 
 build:
-	docker build -t cachet/docker .
+	docker build -t ${REPOSITORY}:${VERSION} --label GITREV=${GITREV} --label BUILD_TIME=${BUILD_TIME} --build-arg cachet_ver=${VERSION} .
+
+push: build
+	docker push -t ${REPOSITORY}:${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ build:
 	docker build -t ${REPOSITORY}:${VERSION} --label GITREV=${GITREV} --label BUILD_TIME=${BUILD_TIME} --build-arg cachet_ver=${VERSION} .
 
 push: build
-	docker push -t ${REPOSITORY}:${VERSION}
+	docker push ${REPOSITORY}:${VERSION}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Cachet Docker Image
 
+This is a Klarrio fork of the Cachet docker images repository.
+To build use the make commands. The component must be released and the binary mush exist in GitHub.
+The produced docker build image should be pushed to the docker registry.
+
+## Documentation
+
 This is the official repository of the [Docker image](https://hub.docker.com/r/cachethq/docker/) for [Cachet](https://github.com/CachetHQ/Cachet).
 
 [Cachet](https://github.com/CachetHQ/Cachet) is a beautiful and powerful open source status page system, a free replacement for services such as StatusPage.io, Status.io and others.


### PR DESCRIPTION
The version was defined twice, which is always a great way to break things, now this reduces it to once and documents the build and push logic.